### PR TITLE
medicament-veto

### DIFF
--- a/db/migrate/20231219135336_add_column_to_medicaments.rb
+++ b/db/migrate/20231219135336_add_column_to_medicaments.rb
@@ -1,0 +1,5 @@
+class AddColumnToMedicaments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :medicaments, :medoc_veto, :boolean, default: false
+  end
+end


### PR DESCRIPTION
Séparation de medicaments pour veto et pour les humains
On a bloqué les bouton des quantité sur la bar de recherche
Migration de medoc_veto